### PR TITLE
Fix Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,55 +17,46 @@ jobs:
 
   build:
     needs: [Test]  # Wait for the tests to succeed
-    runs-on: ${{ matrix.job.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu:centos, use-cross: true  , extension: ""   }
-          - { os: ubuntu-latest  , target: armv7-unknown-linux-gnueabihf  , use-cross: true  , extension: ""   }
-          - { os: ubuntu-latest  , target: aarch64-unknown-linux-gnu      , use-cross: true  , extension: ""   }
-          - { os: macos-latest   , target: x86_64-apple-darwin            , use-cross: false , extension: ""   }
-          - { os: macos-latest   , target: aarch64-apple-darwin           , use-cross: false , extension: ""   }
-          - { os: windows-latest , target: x86_64-pc-windows-msvc         , use-cross: false , extension: .exe }
+            - {"target": "x86_64-unknown-linux-gnu:centos", "extension": "", "target_name": "x86_64-unknown-linux-gnu:centos"}
+            - {"target": "x86_64-apple-darwin", "extension": "", "target_name": "x86_64-apple-darwin"}
+            - {"target": "x86_64-pc-windows-msvc", "extension": ".exe", "target_name": "x86_64-pc-windows-msvc"}
+            - {"target": "aarch64-apple-darwin", "extension": "", "target_name": "aarch64-apple-darwin"}
+            - {"target": "aarch64-unknown-linux-gnu:centos", "extension": "", "target_name": "aarch64-unknown-linux-gnu:centos"}
+            - {"target": "armv7-unknown-linux-gnueabihf", "extension": "", "target_name": "armv7-unknown-linux-gnueabihf"}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Rustのpackage名を取得して環境変数に入れておく。(後のステップで使用)
+      # Get the package name from Cargo.toml and set it as an environment variablea
       - name: Extract crate information
         shell: bash
         run: |
           echo "PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
-
-      # rustcやcargoをインストール
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.job.target }}
-          override: true
-          profile: minimal
-
-      # targetに応じてcargoもしくはcrossを使用してビルド
+          
+      # Install Cross
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+        
+      # Build the project
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.job.use-cross }}
-          command: build
-          args: --release --target ${{ matrix.job.target }}
+        run: cross build --release --target ${{ matrix.job.target }} --verbose
 
       # ビルド済みバイナリをリネーム
       - name: Rename artifacts
         shell: bash
         run: |
-          mv target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}{,-${{ github.ref_name }}-${{ matrix.job.target }}${{ matrix.job.extension }}}
+          mv target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}{,-${{ github.ref_name }}-${{ matrix.job.target_name }}${{ matrix.job.extension }}}
 
       # ビルド済みバイナリをReleasesに配置
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}-${{ github.ref_name }}-${{ matrix.job.target }}${{ matrix.job.extension }}
+            target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}-${{ github.ref_name }}-${{ matrix.job.target_name }}${{ matrix.job.extension }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,9 +31,10 @@ jobs:
   check:
     name: Rustfmt
     runs-on: ubuntu-latest
+    container:
+      image: rust:latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Rust
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run rustfmt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,24 +21,12 @@ jobs:
       - name: Preparing test
         run: "apt-get update && apt-get install ssh adduser sed python3 -y && sed -i 's/^Port 2222$/Port 22/' /etc/ssh/sshd_config && service ssh start && service ssh reload && useradd -m test && printf \'password\\npassword\\n\' | passwd test"
       - uses: actions/checkout@v3
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
       - name: Test Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose
+        run: cargo build --verbose
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose
 
   check:
     name: Rustfmt
@@ -46,21 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
     needs: ["check"]
     steps:
       - name: Preparing test
-        run: "sudo apt-get update && sudo apt-get install ssh adduser sed python3 -y && sudo sed -i 's/^Port 2222$/Port 22/' /etc/ssh/sshd_config && sudo service ssh start && sudo service ssh reload && sudo useradd -m test && printf \'password\\npassword\\n\' | passwd test"
+        run: "sudo apt-get update && sudo apt-get install ssh adduser sed python3 -y && sudo sed -i 's/^Port 2222$/Port 22/' /etc/ssh/sshd_config && sudo service ssh start && sudo service ssh reload && sudo useradd -m test && printf \'password\\npassword\\n\' | sudo passwd test"
       - uses: actions/checkout@v3
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,12 +14,10 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    container:
-      image: rust:latest
     needs: ["check"]
     steps:
       - name: Preparing test
-        run: "apt-get update && apt-get install ssh adduser sed python3 -y && sed -i 's/^Port 2222$/Port 22/' /etc/ssh/sshd_config && service ssh start && service ssh reload && useradd -m test && printf \'password\\npassword\\n\' | passwd test"
+        run: "sudo apt-get update && sudo apt-get install ssh adduser sed python3 -y && sudo sed -i 's/^Port 2222$/Port 22/' /etc/ssh/sshd_config && sudo service ssh start && sudo service ssh reload && sudo useradd -m test && printf \'password\\npassword\\n\' | passwd test"
       - uses: actions/checkout@v3
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -31,8 +29,6 @@ jobs:
   check:
     name: Rustfmt
     runs-on: ubuntu-latest
-    container:
-      image: rust:latest
     steps:
       - uses: actions/checkout@v3
       - name: Cache Rust dependencies

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,6 +37,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+      - name: Install Rust fmt
+        run: rustup component add rustfmt
+      - name: Install Rust clippy
+        run: rustup component add clippy
       - name: Run rustfmt
         run: cargo fmt --all -- --check
       - name: Run clippy

--- a/src/cputemp.rs
+++ b/src/cputemp.rs
@@ -1313,7 +1313,7 @@ mod test {
         sleep(Duration::from_secs(2));
 
         // Run the actual test
-        let result = get_ilo_data("https://localhost", "user", "pass").await;
+        let result = get_ilo_data("https://localhost:8080", "user", "pass").await;
         println!("Result: {:#?}", result);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "Hello-World-Test");

--- a/test-https-server/runserver.py
+++ b/test-https-server/runserver.py
@@ -1,7 +1,7 @@
 import ssl
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 
-PORT = 443
+PORT = 8080
 CERTFILE = "./localhost.pem"
 
 Handler = SimpleHTTPRequestHandler


### PR DESCRIPTION
This pull request includes changes to the `jobs:` section in the `.github/workflows/testing.yml` file to simplify the GitHub Actions workflow for testing and checking Rust code. The most important changes include removing the usage of the `actions-rs/toolchain` and `actions-rs/cargo` actions and replacing them with direct `cargo` commands.

Simplification of GitHub Actions workflow:

* Removed the `Setup Rust` step that used `actions-rs/toolchain@v1` and replaced it with direct `cargo` commands for building, testing, formatting, and linting the Rust code. (`.github/workflows/testing.yml`)
* Replaced the `actions-rs/cargo@v1` action with direct `cargo` commands for building the project. (`.github/workflows/testing.yml`)
* Replaced the `actions-rs/cargo@v1` action with direct `cargo` commands for running tests. (`.github/workflows/testing.yml`)
* Replaced the `actions-rs/cargo@v1` action with direct `cargo` commands for formatting the code using `rustfmt`. (`.github/workflows/testing.yml`)
* Replaced the `actions-rs/cargo@v1` action with direct `cargo` commands…rect cargo commands