### PR TITLE
fix: Replace winget with choco for Windows dependency installation in…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,24 +56,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
           
-      # Install Winget
-      - name: Install winget
-        if: ${{  matrix.job.runner == 'windows-latest' }}
-        uses: Cyberboss/install-winget@v1
       # Install Deps on windows
       - name: Install Deps on windows
         if: ${{  matrix.job.runner == 'windows-latest' }}
         run: |
-            winget install -e --id GnuWin32.Make
-            winget install -e --id StrawberryPerl.StrawberryPerl
-            winget install --scope machine Microsoft.VisualStudio.2022.BuildTools 
+            choco install make --yes
       
       # Install Deps on macos
       - name: Install Deps on macos
         if: ${{  matrix.job.runner == 'macos-latest' }}
         run: |
             brew install make
-            brew install perl
           
       # Install Cross
       - name: Install cross


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to streamline the installation process for dependencies on different operating systems.

Dependency installation updates:

* Removed the installation of `winget` and replaced the installation of `make`, `perl`, and `Microsoft.VisualStudio.2022.BuildTools` with `choco` on Windows runners.
* Removed the installation of `perl` on macOS runners.

… release workflow