### PR TITLE
Make change for using base64 encoded password

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ name = "ilo4-fan-control"
 version = "2.0.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "dialoguer",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ toml = "0.8.20"
 dialoguer = "0.11.0"
 openssl-sys = "0.9.106"
 openssl = { version = "0.10.71", features = ["vendored"] }
+base64 = "0.22.1"
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/src/cmds/daemon.rs
+++ b/src/cmds/daemon.rs
@@ -6,6 +6,7 @@ use log::{debug, error, info};
 use crate::config::TargetIlo;
 use crate::cputemp;
 use crate::ssh;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 pub fn start_daemon(config_path: String) -> Result<()> {
     debug!("Starting daemon with config path: {}", config_path);
@@ -68,9 +69,12 @@ async fn daemon_main(config: crate::config::IloConfig) -> Result<()> {
 }
 
 async fn runner(config: TargetIlo) -> Result<()> {
+    let password_base64 = config.password_base64.clone();
     let host = config.host.clone();
     let user = config.user.clone();
-    let password = config.password.clone();
+    
+    let password = STANDARD.decode(password_base64)?;
+    let password = String::from_utf8(password)?;
 
     info!("Fan controller for host: {}", &host);
     debug!("User: {}", &user);

--- a/src/cmds/daemon.rs
+++ b/src/cmds/daemon.rs
@@ -72,7 +72,7 @@ async fn runner(config: TargetIlo) -> Result<()> {
     let password_base64 = config.password_base64.clone();
     let host = config.host.clone();
     let user = config.user.clone();
-    
+
     let password = STANDARD.decode(password_base64)?;
     let password = String::from_utf8(password)?;
 

--- a/src/cmds/sample.rs
+++ b/src/cmds/sample.rs
@@ -28,7 +28,7 @@ pub fn show_sample(path: String, dual: bool) {
     let target_ilo = TargetIlo {
         host: String::from("ILO_HOST_NAME_OR_IP_ADDRESS"),
         user: String::from("USERNAME"),
-        password: String::from("PASSWORD"),
+        password_base64: String::from("PASSWORD_BASE64"),
         target_fans: target_fans.clone(),
         temperature_fan_config: fan_config.clone(),
     };
@@ -41,7 +41,7 @@ pub fn show_sample(path: String, dual: bool) {
         let target_ilo2 = TargetIlo {
             host: String::from("ILO_HOST2_NAME_OR_IP_ADDRESS"),
             user: String::from("USERNAME"),
-            password: String::from("PASSWORD"),
+            password_base64: String::from("PASSWORD_BASE64"),
             target_fans,
             temperature_fan_config: fan_config,
         };

--- a/src/cmds/utils.rs
+++ b/src/cmds/utils.rs
@@ -1,6 +1,6 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use dialoguer::{Input, Password};
 use log::debug;
-use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 pub fn get_connection_info(
     host: Option<String>,
@@ -38,8 +38,6 @@ pub fn get_connection_info(
             .unwrap();
         let decoded = STANDARD.decode(input).unwrap();
         String::from_utf8(decoded).unwrap()
-
-
     });
     debug!("Host: {}", host);
     debug!("User: {}", user);

--- a/src/cmds/utils.rs
+++ b/src/cmds/utils.rs
@@ -1,5 +1,6 @@
 use dialoguer::{Input, Password};
 use log::debug;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 pub fn get_connection_info(
     host: Option<String>,
@@ -35,7 +36,10 @@ pub fn get_connection_info(
             .with_prompt("Enter ilo password")
             .interact()
             .unwrap();
-        input
+        let decoded = STANDARD.decode(input).unwrap();
+        String::from_utf8(decoded).unwrap()
+
+
     });
     debug!("Host: {}", host);
     debug!("User: {}", user);

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,9 +127,9 @@ impl IloConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
     use std::io::Write;
     use tempfile::NamedTempFile;
-    use base64::{engine::general_purpose::STANDARD, Engine as _};
 
     fn create_valid_config() -> IloConfig {
         let password_base64 = STANDARD.encode("password123");

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,8 +28,8 @@ pub struct TargetIlo {
     pub host: String,
     /// Username for ILO authentication
     pub user: String,
-    /// Password for ILO authentication
-    pub password: String,
+    /// Base64 encoded password for ILO authentication
+    pub password_base64: String,
     /// Fan control target configuration
     pub target_fans: TargetFans,
     /// Temperature-based fan speed configuration
@@ -129,15 +129,18 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
 
     fn create_valid_config() -> IloConfig {
+        let password_base64 = STANDARD.encode("password123");
+        let password_base64_456 = STANDARD.encode("password456");
         IloConfig {
             run_period_seconds: 60,
             targets: vec![
                 TargetIlo {
                     host: "192.168.1.100".to_string(),
                     user: "admin".to_string(),
-                    password: "password123".to_string(),
+                    password_base64,
                     target_fans: TargetFans::NumFans(3),
                     temperature_fan_config: vec![
                         FanConfig {
@@ -155,7 +158,7 @@ mod tests {
                 TargetIlo {
                     host: "192.168.1.101".to_string(),
                     user: "admin".to_string(),
-                    password: "password456".to_string(),
+                    password_base64: password_base64_456,
                     target_fans: TargetFans::TargetFans(vec![1, 2]),
                     temperature_fan_config: vec![
                         FanConfig {

--- a/src/gen_ssh.rs
+++ b/src/gen_ssh.rs
@@ -113,7 +113,6 @@ mod tests {
     fn test_generate_fan_commands_num_fans() {
         // NumFans形式でのテスト
         let target = create_test_target(TargetFans::NumFans(3));
-        let password: String = STANDARD.encode("password123");
 
         // 低温域でのテスト (0-30℃)
         let low_temp_commands = generate_fan_commands(&target, 25);

--- a/src/gen_ssh.rs
+++ b/src/gen_ssh.rs
@@ -214,7 +214,6 @@ mod tests {
 
         let password: String = STANDARD.encode("password123");
         for (percentage, expected) in test_cases.iter() {
-
             let target = TargetIlo {
                 host: String::from("example.com"),
                 user: String::from("admin"),

--- a/src/gen_ssh.rs
+++ b/src/gen_ssh.rs
@@ -19,7 +19,7 @@ use crate::config::{TargetFans, TargetIlo};
 /// let target_ilo = TargetIlo {
 ///     host: String::from("example_host"), // Added host initialization
 ///     user: String::from("admin"),
-///     password: String::from("password"),
+///     password_base64: String::from("password_base64"),
 ///     
 ///     target_fans: TargetFans::NumFans(4),
 ///     temperature_fan_config: vec![
@@ -78,13 +78,16 @@ pub fn generate_fan_commands(target: &TargetIlo, current_temp: u8) -> Vec<String
 mod tests {
     use super::*;
     use crate::config::FanConfig;
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
 
     /// テスト用のTargetIloインスタンスを作成する補助関数
     fn create_test_target(fan_type: TargetFans) -> TargetIlo {
+        let password: String = STANDARD.encode("password123");
+
         TargetIlo {
             host: String::from("example.host.com"),
             user: String::from("admin"),
-            password: String::from("password"),
+            password_base64: password,
             target_fans: fan_type,
             temperature_fan_config: vec![
                 FanConfig {
@@ -110,6 +113,7 @@ mod tests {
     fn test_generate_fan_commands_num_fans() {
         // NumFans形式でのテスト
         let target = create_test_target(TargetFans::NumFans(3));
+        let password: String = STANDARD.encode("password123");
 
         // 低温域でのテスト (0-30℃)
         let low_temp_commands = generate_fan_commands(&target, 25);
@@ -154,6 +158,7 @@ mod tests {
     fn test_generate_fan_commands_out_of_range() {
         // 温度範囲外のケース
         let target = create_test_target(TargetFans::NumFans(2));
+        let password: String = STANDARD.encode("password123");
 
         // 設定された範囲よりも高温
         let high_out_commands = generate_fan_commands(&target, 90);
@@ -167,7 +172,7 @@ mod tests {
         let target_with_gap = TargetIlo {
             host: String::from("example.com"),
             user: String::from("admin"),
-            password: String::from("password"),
+            password_base64: password,
             target_fans: TargetFans::NumFans(1),
             temperature_fan_config: vec![
                 FanConfig {
@@ -207,11 +212,13 @@ mod tests {
             (100, 255), // 255
         ];
 
+        let password: String = STANDARD.encode("password123");
         for (percentage, expected) in test_cases.iter() {
+
             let target = TargetIlo {
                 host: String::from("example.com"),
                 user: String::from("admin"),
-                password: String::from("password"),
+                password_base64: password.clone(),
                 target_fans: TargetFans::NumFans(1),
                 temperature_fan_config: vec![FanConfig {
                     min_temp: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
     /// iLO4 username
     #[arg(long)]
     user: Option<String>,
-    /// iLO4 password
+    /// iLO4 base64 encoded password
     #[arg(long)]
     password: Option<String>, // Changed to Option<String>
 


### PR DESCRIPTION
This pull request includes several changes to the codebase to switch from using plain text passwords to base64 encoded passwords. The most important changes include updating the `TargetIlo` struct, modifying functions to handle base64 decoding, and updating tests accordingly.

### Base64 Encoding Changes:

* [`src/config.rs`](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL31-R32): Updated the `TargetIlo` struct to use `password_base64` instead of `password`.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R33): Added the `base64` crate as a dependency.

### Function Modifications:

* [`src/cmds/daemon.rs`](diffhunk://#diff-ca9e2b29d3d848d87958fa130c43f4a1fd891200760d42169dfa3882089c5855R72-R77): Modified the `runner` function to decode the base64 encoded password.
* [`src/cmds/utils.rs`](diffhunk://#diff-852b70605f3329fd6c6e908e86264d728387be0dba7c68fc8517c30db7fa6c68L38-R42): Updated the `get_connection_info` function to decode the base64 encoded password input.

### Test Updates:

* [`src/config.rs`](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR132-R143): Updated tests to use base64 encoded passwords. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR132-R143) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL158-R161)
* [`src/gen_ssh.rs`](diffhunk://#diff-2011ff23c6b8f4adf49fee6413457da92c9b90bc9e1a19ae243f99ae32cfe7a8R81-R90): Updated tests and helper functions to use base64 encoded passwords. [[1]](diffhunk://#diff-2011ff23c6b8f4adf49fee6413457da92c9b90bc9e1a19ae243f99ae32cfe7a8R81-R90) [[2]](diffhunk://#diff-2011ff23c6b8f4adf49fee6413457da92c9b90bc9e1a19ae243f99ae32cfe7a8R116) [[3]](diffhunk://#diff-2011ff23c6b8f4adf49fee6413457da92c9b90bc9e1a19ae243f99ae32cfe7a8R161) [[4]](diffhunk://#diff-2011ff23c6b8f4adf49fee6413457da92c9b90bc9e1a19ae243f99ae32cfe7a8L170-R175) [[5]](diffhunk://#diff-2011ff23c6b8f4adf49fee6413457da92c9b90bc9e1a19ae243f99ae32cfe7a8R215-R221)

These changes ensure that passwords are handled more securely by encoding them in base64 format.